### PR TITLE
Built-in per-route monitoring thanks to VaporMonitoring and SwiftPrometheus

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -201,11 +201,11 @@
       },
       {
         "package": "SwiftPrometheus",
-        "repositoryURL": "https://github.com/MrLotU/SwiftPrometheus",
+        "repositoryURL": "https://github.com/Yasumoto/SwiftPrometheus.git",
         "state": {
-          "branch": "MetricsLib",
-          "revision": "700ff7a5f2f760a59ef32d585aea2152bbf7b1be",
-          "version": null
+          "branch": null,
+          "revision": "37237516f92a18148d6ae2ccbc378481b21fe07d",
+          "version": "1.0.0-yasumoto.1"
         }
       },
       {
@@ -251,6 +251,15 @@
           "branch": null,
           "revision": "c86ada59b31c69f08a6abd4f776537cba48d5df6",
           "version": "3.3.0"
+        }
+      },
+      {
+        "package": "VaporMonitoring",
+        "repositoryURL": "https://github.com/Yasumoto/VaporMonitoring.git",
+        "state": {
+          "branch": "yasumoto-fork-the-things",
+          "revision": "9ded4c6c337be53e8648a68dd3287a41aec6c699",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,14 +17,20 @@ let package = Package(
         .package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.0.2"),
 
         // 🔥 Prometheus
-        .package(url: "https://github.com/MrLotU/SwiftPrometheus", .branch("MetricsLib")),
+        .package(url: "https://github.com/Yasumoto/SwiftPrometheus.git", from: "1.0.0-yasumoto.1"),
 
-        // 📈 Metrics
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "1.0.0"),
-
+        // 📈 Metrics & Monitoring
+        .package(url: "https://github.com/Yasumoto/VaporMonitoring.git", .branch("yasumoto-fork-the-things"))
     ],
     targets: [
-        .target(name: "App", dependencies: ["FluentDynamoDB", "Leaf", "Backtrace", "Vapor", "SwiftPrometheus", "Metrics"]),
+        .target(name: "App", dependencies: [
+            "Backtrace",
+            "FluentDynamoDB",
+            "Leaf",
+            "SwiftPrometheus",
+            "Vapor",
+            "VaporMonitoring"
+        ]),
         .target(name: "Run", dependencies: ["App"]),
         .testTarget(name: "AppTests", dependencies: ["App"])
     ]

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -3,9 +3,9 @@
 #set("body") {
   <div class="welcome">
   #if(lock.isIncidentOngoing) {
-    <h1>🍎 WARNING! Global hold on changes!</h1>
+    <h1>🍎 WARNING! Global Hold on Loadtests!</h1>
 } else {
-    <h1>🍐 All's well</h1>
+    <h1>🍐 All's Well — Loadtesting May Proceed</h1>
   }
   <table class="table table-bordered table-hover">
   <thead class="thead-light">


### PR DESCRIPTION
This will look like (on `/metrics`):

```
# TYPE http_requests_total counter
http_requests_total 0
http_requests_total{status_code="500", path="/status", method="GET"} 2
http_requests_total{status_code="200", path="/metrics", method="GET"} 3
http_requests_total{status_code="500", path="/", method="GET"} 4
http_requests_total{status_code="200", path="/health", method="GET"} 2
# TYPE http_requests_duration_seconds summary
http_requests_duration_seconds{quantile="0.01"} 0.000259041
http_requests_duration_seconds{quantile="0.05"} 0.000259041
http_requests_duration_seconds{quantile="0.5"} 0.289999008
http_requests_duration_seconds{quantile="0.9"} 0.310270905
http_requests_duration_seconds{quantile="0.95"} 0.340256094
http_requests_duration_seconds{quantile="0.99"} 0.340256094
http_requests_duration_seconds{quantile="0.999"} 0.340256094
http_requests_duration_seconds_count 11
http_requests_duration_seconds_sum 1
http_requests_duration_seconds{status_code="200", quantile="0.01", path="/metrics", method="GET"} 0.000995993
http_requests_duration_seconds{status_code="200", quantile="0.05", path="/metrics", method="GET"} 0.000995993
http_requests_duration_seconds{status_code="200", quantile="0.5", path="/metrics", method="GET"} 0.00285995
http_requests_duration_seconds{status_code="200", quantile="0.9", path="/metrics", method="GET"} 0.002887964
http_requests_duration_seconds{status_code="200", quantile="0.95", path="/metrics", method="GET"} 0.002887964
http_requests_duration_seconds{status_code="200", quantile="0.99", path="/metrics", method="GET"} 0.002887964
http_requests_duration_seconds{status_code="200", quantile="0.999", path="/metrics", method="GET"} 0.002887964
http_requests_duration_seconds_count{status_code="200", path="/metrics", method="GET"} 3
http_requests_duration_seconds_sum{status_code="200", path="/metrics", method="GET"} 0
http_requests_duration_seconds{status_code="500", quantile="0.01", path="/", method="GET"} 0.293069005
http_requests_duration_seconds{status_code="500", quantile="0.05", path="/", method="GET"} 0.293069005
http_requests_duration_seconds{status_code="500", quantile="0.5", path="/", method="GET"} 0.3019359705
http_requests_duration_seconds{status_code="500", quantile="0.9", path="/", method="GET"} 0.340256094
http_requests_duration_seconds{status_code="500", quantile="0.95", path="/", method="GET"} 0.340256094
http_requests_duration_seconds{status_code="500", quantile="0.99", path="/", method="GET"} 0.340256094
http_requests_duration_seconds{status_code="500", quantile="0.999", path="/", method="GET"} 0.340256094
http_requests_duration_seconds_count{status_code="500", path="/", method="GET"} 4
http_requests_duration_seconds_sum{status_code="500", path="/", method="GET"} 1
http_requests_duration_seconds{status_code="500", quantile="0.01", path="/status", method="GET"} 0.289999008
http_requests_duration_seconds{status_code="500", quantile="0.05", path="/status", method="GET"} 0.289999008
http_requests_duration_seconds{status_code="500", quantile="0.5", path="/status", method="GET"} 0.289999008
http_requests_duration_seconds{status_code="500", quantile="0.9", path="/status", method="GET"} 0.291983962
http_requests_duration_seconds{status_code="500", quantile="0.95", path="/status", method="GET"} 0.291983962
http_requests_duration_seconds{status_code="500", quantile="0.99", path="/status", method="GET"} 0.291983962
http_requests_duration_seconds{status_code="500", quantile="0.999", path="/status", method="GET"} 0.291983962
http_requests_duration_seconds_count{status_code="500", path="/status", method="GET"} 2
http_requests_duration_seconds_sum{status_code="500", path="/status", method="GET"} 0
http_requests_duration_seconds{status_code="200", quantile="0.01", path="/health", method="GET"} 0.000259041
http_requests_duration_seconds{status_code="200", quantile="0.05", path="/health", method="GET"} 0.000259041
http_requests_duration_seconds{status_code="200", quantile="0.5", path="/health", method="GET"} 0.000259041
http_requests_duration_seconds{status_code="200", quantile="0.9", path="/health", method="GET"} 0.000380992
http_requests_duration_seconds{status_code="200", quantile="0.95", path="/health", method="GET"} 0.000380992
http_requests_duration_seconds{status_code="200", quantile="0.99", path="/health", method="GET"} 0.000380992
http_requests_duration_seconds{status_code="200", quantile="0.999", path="/health", method="GET"} 0.000380992
http_requests_duration_seconds_count{status_code="200", path="/health", method="GET"} 2
http_requests_duration_seconds_sum{status_code="200", path="/health", method="GET"} 0
```